### PR TITLE
Fix placing blocks

### DIFF
--- a/server/src/main/java/com/voxelwind/server/game/inventories/transaction/record/ContainerTransactionRecord.java
+++ b/server/src/main/java/com/voxelwind/server/game/inventories/transaction/record/ContainerTransactionRecord.java
@@ -27,6 +27,6 @@ public class ContainerTransactionRecord extends TransactionRecord{
 
     @Override
     public void execute(PlayerSession session) {
-        // TODO
+        session.getInventory().setItem (getSlot(), getNewItem());
     }
 }


### PR DESCRIPTION
If player moves the block to another slot, the block moves to the 0 slot.
This pull fix it bug.